### PR TITLE
2019081200 release code

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,19 @@
+<?php
+// …
+ 
+namespace tinymce_panoptobutton\privacy;
+ 
+class provider implements
+    // This plugin does not store any personal user data.
+    \core_privacy\local\metadata\null_provider {
+ 
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/tinymce_panoptobutton.php
+++ b/lang/en/tinymce_panoptobutton.php
@@ -25,4 +25,5 @@ $string['pluginname'] = 'Add Panopto Video';
 $string['panopto_button_description'] = 'Add Panopto Video';
 $string['panopto_button_long_description'] = 'Add Panopto Video Content to TinyMCE';
 $string['panopto_button_unprovisioned_error'] = 'Error: Please use the Panopto Block to provision this course before using this tool';
+$string['privacy:metadata'] = '';
 

--- a/lib.php
+++ b/lib.php
@@ -79,6 +79,11 @@ class tinymce_panoptobutton extends editor_tinymce_plugin {
             $params['panoptoid'] = $panoptoid;
         }
 
+        $instancename = get_config('block_panopto', 'instance_name');
+        if (!empty($instancename)) {
+            $params['instancename'] = $instancename;
+        }
+
         $params['panoptobuttondescription'] = get_string('panopto_button_description', 'tinymce_panoptobutton');
         $params['panoptobuttonlongdescription'] = get_string('panopto_button_long_description', 'tinymce_panoptobutton');
         $params['unprovisionederror'] = get_string('panopto_button_unprovisioned_error', 'tinymce_panoptobutton');

--- a/tinymce/editor_plugin.js
+++ b/tinymce/editor_plugin.js
@@ -9,13 +9,20 @@
         init: function (ed, url) {
             // Register the command so that it can be invoked by using tinyMCE.activeEditor.execCommand('mceExample').
             ed.addCommand('mcePanopto', function () {
-                var baseUrl = ed.getParam('moodle_plugin_base') + 'panoptobutton/tinymce/panoptowrapper.html#';
+                var baseUrl = ed.getParam('moodle_plugin_base') + 'panoptobutton/tinymce/panoptowrapper.html#',
+                    instanceParam = ed.getParam('instancename'),
+                    instanceString = '';
 
                 baseUrl += 'unprovisionerror=' + encodeURIComponent(ed.getParam('unprovisionederror'));
                 
+                if (instanceParam) {
+                    instanceString = '&instance=' + instanceParam;
+                }
+
                 if (ed.getParam('panoptoservername') != null &&
                     ed.getParam('panoptoid') != null) {
                     baseUrl += '&servername=' + ed.getParam('panoptoservername') +
+                               instanceString + 
                                '&panoptoid=' + ed.getParam('panoptoid');
                 }
 

--- a/tinymce/panoptowrapper.html
+++ b/tinymce/panoptowrapper.html
@@ -17,6 +17,8 @@
         var servername = getHashValue('servername'),
             // Get the Id of the active panopto course folder.
             panoptoid   = getHashValue('panoptoid'),
+            instanceParam   = getHashValue('instance'),
+            instanceString = ''
             unprovisionederror = decodeURIComponent(getHashValue('unprovisionerror'));
 
         $(document).ready(function () {
@@ -26,13 +28,17 @@
                 eventEnter = window[eventMethod],
                 messageEvent = eventMethod === 'attachEvent' ? 'onmessage' : 'message';
 
+            if (instanceParam) {
+                instanceString = '&instance=' + instanceParam;
+            }
+
             if (!panoptoid || !servername) {
                 // Add the panopto error text to the error container. Also hide the iframe so the user does not try to access a broken iframe.
                 $('#errorcontainer').css("display", "block");
                 $('#pageframe').css("display", "none");
                 $('#errorcontainer').html(unprovisionederror);
             } else {
-                $('#pageframe').attr('src', 'https://' + servername + '/Panopto/Pages/Sessions/EmbeddedUpload.aspx?playlistsEnabled=true&folderID=' + panoptoid);
+                $('#pageframe').attr('src', 'https://' + servername + '/Panopto/Pages/Sessions/EmbeddedUpload.aspx?playlistsEnabled=true' + instanceString + '&folderID=' + panoptoid);
             }
             //Hide insert button initially, until a video is selected
             $('#insert').hide();

--- a/tinymce/panoptowrapper.html
+++ b/tinymce/panoptowrapper.html
@@ -38,7 +38,8 @@
                 $('#pageframe').css("display", "none");
                 $('#errorcontainer').html(unprovisionederror);
             } else {
-                $('#pageframe').attr('src', 'https://' + servername + '/Panopto/Pages/Sessions/EmbeddedUpload.aspx?playlistsEnabled=true' + instanceString + '&folderID=' + panoptoid);
+                servername = 'https://' + servername;
+                $('#pageframe').attr('src', servername + '/Panopto/Pages/Sessions/EmbeddedUpload.aspx?playlistsEnabled=true' + instanceString + '&folderID=' + panoptoid);
             }
             //Hide insert button initially, until a video is selected
             $('#insert').hide();

--- a/version.php
+++ b/version.php
@@ -23,6 +23,15 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019070100;  // The current plugin version (Date: YYYYMMDDXX).
-$plugin->requires  = 2014051200;  // Requires this Moodle version - 2.7.
-$plugin->component = 'tinymce_panoptobutton';  // Full name of the plugin (used for diagnostics).
+
+// The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2019081200;  
+
+// Requires this Moodle version - 2.7.
+$plugin->requires  = 2014051200;  
+
+// Full name of the plugin (used for diagnostics).
+$plugin->component = 'tinymce_panoptobutton';  
+
+// This is considered as ready for production sites.
+$plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This is the latest version of Panopto button for TinyMCE plug-in.
- Fixed an issue where insertion failed. This was introduced by the last release 2019070100 and Panopto has withdrawn that version because this bug affected widely. Panopto thanks Matt Davidson who reported this issue with the fix proposed.
- Added privacy provider to the plugin. Note that this provider tells the behavior of this plug-in, but the behavior itself is unchanged by this version.
- Fixed an issue where the plugin did not work correctly if same Panopto site was integrated to two or more Moodle sites on the same server FQDN.
